### PR TITLE
feat: add MiniMax LLM provider support (M2.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Exit code 1 if trust score is below threshold. SARIF output supported via `--out
 |---|---|:---:|
 | OpenAI | `--model gpt-4o` | `OPENAI_API_KEY` |
 | Anthropic | `--model claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` |
+| MiniMax | `--model MiniMax-M2.7` | `MINIMAX_API_KEY` |
 | Ollama | `--model ollama/llama3.1:8b` | None |
 | LiteLLM | `--model any --litellm-url http://...` | Varies |
 | HTTP | `--url http://your-agent.com/chat` | None |

--- a/python/agentseal/cli.py
+++ b/python/agentseal/cli.py
@@ -156,11 +156,11 @@ def main():
 
     # Model (required for prompt/file mode)
     scan_parser.add_argument("--model", "-m", type=str, default=None,
-                             help="Model to test against (e.g. gpt-4o, claude-sonnet-4-5-20250929, ollama/qwen3-32b)")
+                             help="Model to test against (e.g. gpt-4o, claude-sonnet-4-5-20250929, MiniMax-M2.7, ollama/qwen3-32b)")
 
     # LLM connection
     scan_parser.add_argument("--api-key", type=str, default=None,
-                             help="API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY env)")
+                             help="API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / MINIMAX_API_KEY env)")
     scan_parser.add_argument("--ollama-url", type=str, default=None,
                              help="Ollama base URL (default: http://localhost:11434)")
     scan_parser.add_argument("--litellm-url", type=str, default=None,
@@ -271,7 +271,7 @@ def main():
     watch_parser.add_argument("--model", "-m", type=str, default=None,
                                help="Model to test against")
     watch_parser.add_argument("--api-key", type=str, default=None,
-                               help="API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY env)")
+                               help="API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / MINIMAX_API_KEY env)")
     watch_parser.add_argument("--ollama-url", type=str, default=None,
                                help="Ollama base URL (default: http://localhost:11434)")
     watch_parser.add_argument("--litellm-url", type=str, default=None,

--- a/python/agentseal/config.py
+++ b/python/agentseal/config.py
@@ -26,7 +26,7 @@ _CONFIG_FILE = _CONFIG_DIR / "config.json"
 # Valid config keys and their descriptions
 _VALID_KEYS = {
     "model": "Default LLM model (e.g. claude-haiku-4-5-20251001, gpt-4o, ollama/qwen3.5:cloud)",
-    "api-key": "API key for OpenAI/Anthropic/OpenRouter",
+    "api-key": "API key for OpenAI/Anthropic/MiniMax/OpenRouter",
     "ollama-url": "Ollama base URL (default: http://localhost:11434)",
     "litellm-url": "LiteLLM proxy URL for custom LLM routing",
     "registry-url": "Custom URL for MCP server registry updates",
@@ -57,6 +57,12 @@ def get_setup_guide() -> str:
     agentseal config set model gpt-4o-mini
     agentseal config set api-key sk-xxxxx
     # Or: export OPENAI_API_KEY=sk-xxxxx
+
+  MiniMax:
+    agentseal config set model MiniMax-M2.7
+    agentseal config set api-key xxxxx
+    # Or: export MINIMAX_API_KEY=xxxxx
+    # Models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 
   OpenRouter (any model, one API key):
     agentseal config set model openrouter/anthropic/claude-haiku-4-5-20251001

--- a/python/agentseal/connectors/__init__.py
+++ b/python/agentseal/connectors/__init__.py
@@ -14,6 +14,7 @@ from agentseal.connectors.anthropic import build_anthropic_chat
 from agentseal.connectors.ollama import build_ollama_chat
 from agentseal.connectors.litellm import build_litellm_chat
 from agentseal.connectors.http import build_http_chat
+from agentseal.connectors.minimax import build_minimax_chat
 
 
 def build_agent_fn(model: str, system_prompt: str, api_key: str = None,
@@ -24,6 +25,7 @@ def build_agent_fn(model: str, system_prompt: str, api_key: str = None,
       - "ollama/..." → Ollama
       - litellm_url set → LiteLLM proxy
       - "claude"/"anthropic" in name → Anthropic
+      - "minimax" in name → MiniMax
       - else → OpenAI-compatible
     """
     if model.startswith("ollama/"):
@@ -49,6 +51,13 @@ def build_agent_fn(model: str, system_prompt: str, api_key: str = None,
             api_key=api_key,
         )
 
+    if "minimax" in model.lower():
+        return build_minimax_chat(
+            model=model,
+            system_prompt=system_prompt,
+            api_key=api_key,
+        )
+
     return build_openai_chat(
         model=model,
         system_prompt=system_prompt,
@@ -63,4 +72,5 @@ __all__ = [
     "build_ollama_chat",
     "build_litellm_chat",
     "build_http_chat",
+    "build_minimax_chat",
 ]

--- a/python/agentseal/connectors/minimax.py
+++ b/python/agentseal/connectors/minimax.py
@@ -1,0 +1,41 @@
+# agentseal/connectors/minimax.py
+"""
+MiniMax connector via raw HTTP (for CLI use).
+
+Layer 3: no agentseal imports.
+"""
+
+import os
+
+
+def build_minimax_chat(model: str, system_prompt: str, api_key: str = None):
+    """Build an async chat function for the MiniMax Chat Completions API.
+
+    MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+
+    Args:
+        model: Model name (e.g. "MiniMax-M2.7", "MiniMax-M2.7-highspeed").
+        system_prompt: The system prompt to use.
+        api_key: API key (falls back to MINIMAX_API_KEY env).
+    """
+    import httpx
+
+    key = api_key or os.environ.get("MINIMAX_API_KEY", "")
+
+    async def chat(message: str) -> str:
+        url = "https://api.minimax.io/v1/chat/completions"
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(url, json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": message},
+                ],
+            }, headers={
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+            })
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+
+    return chat

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -192,9 +192,10 @@ class TestCanonicalImports:
         from agentseal.connectors.ollama import build_ollama_chat
         from agentseal.connectors.litellm import build_litellm_chat
         from agentseal.connectors.http import build_http_chat
+        from agentseal.connectors.minimax import build_minimax_chat
         assert all(callable(f) for f in [
             build_openai_chat, build_anthropic_chat, build_ollama_chat,
-            build_litellm_chat, build_http_chat,
+            build_litellm_chat, build_http_chat, build_minimax_chat,
         ])
 
     def test_scoring(self):


### PR DESCRIPTION
## Summary
Add MiniMax as a first-class LLM provider, using the latest M2.7 flagship model as default.

## Changes
- Add `python/agentseal/connectors/minimax.py` — raw httpx connector for MiniMax OpenAI-compatible API
- Route `minimax` model names in `build_agent_fn()` to MiniMax connector
- Update CLI help text with MiniMax model example and `MINIMAX_API_KEY` env var
- Add MiniMax section to config setup guide (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed)
- Add MiniMax row to README Supported Providers table
- Add minimax import to test_imports

## Usage
```bash
agentseal config set model MiniMax-M2.7
export MINIMAX_API_KEY=your-key
agentseal scan --prompt "You are a helpful assistant..." --model MiniMax-M2.7
```

## Models
- `MiniMax-M2.7` — Latest flagship model with enhanced reasoning and coding
- `MiniMax-M2.7-highspeed` — High-speed version for low-latency scenarios
- `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` — Previous generation (still available)

## Testing
- Import tests pass
- Config guide verified to include MiniMax section