### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The npm package provides the same CLI commands (`agentseal guard`, `scan`, `scan
 |---|---|:---:|
 | OpenAI | `--model gpt-4o` | `OPENAI_API_KEY` |
 | Anthropic | `--model claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` |
-| MiniMax | `--model MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| MiniMax | `--model MiniMax-M3` | `MINIMAX_API_KEY` |
 | Ollama | `--model ollama/llama3.1:8b` | None |
 | LiteLLM | `--model any --litellm-url http://...` | Varies |
 | HTTP | `--url http://your-agent.com/chat` | None |

--- a/python/agentseal/config.py
+++ b/python/agentseal/config.py
@@ -59,10 +59,10 @@ def get_setup_guide() -> str:
     # Or: export OPENAI_API_KEY=sk-xxxxx
 
   MiniMax:
-    agentseal config set model MiniMax-M2.7
+    agentseal config set model MiniMax-M3
     agentseal config set api-key xxxxx
     # Or: export MINIMAX_API_KEY=xxxxx
-    # Models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+    # Models: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed
 
   OpenRouter (any model, one API key):
     agentseal config set model openrouter/anthropic/claude-haiku-4-5-20251001


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to use M3 as the default model.

## Changes

- Set MiniMax-M3 as the default model in `config.py` setup guide and `README.md`
- MiniMax-M3 offers 512K context window, up to 128K output, and image input support
- Keep MiniMax-M2.7 and MiniMax-M2.7-highspeed as alternatives
- Remove older MiniMax-M2.5 variants from recommended models list

## Testing

- Connector router (`build_agent_fn`) already routes based on `"minimax" in model.lower()`, which matches any MiniMax-M* model
- All MiniMax connector code works identically regardless of model name (it's passed as a string to the API)

Closes #30